### PR TITLE
Fix scheduler tab summary selectors for Backdrop CMS

### DIFF
--- a/js/scheduler_vertical_tabs.js
+++ b/js/scheduler_vertical_tabs.js
@@ -22,10 +22,10 @@ Backdrop.behaviors.scheduler_settings = {
     // Provide summary when editing a node.
     $('fieldset#edit-scheduler-settings', context).backdropSetSummary(function(context) {
       var vals = [];
-      if ($('#edit-publish-on').val() || $('#edit-publish-on-datepicker-popup-0').val()) {
+      if ($('#edit-publish-on-date').val()) {
         vals.push(Backdrop.t('Scheduled for publishing'));
       }
-      if ($('#edit-unpublish-on').val() || $('#edit-unpublish-on-datepicker-popup-0').val()) {
+      if ($('#edit-unpublish-on-date').val()) {
         vals.push(Backdrop.t('Scheduled for unpublishing'));
       }
       if (!vals.length) {


### PR DESCRIPTION
The tab summary for scheduled publishing/unpublishing was always displaying "Not scheduled" due to incorrect CSS selectors targeting non-existent elements from the Drupal 7 version.

- Replace #edit-publish-on with #edit-publish-on-date
- Replace #edit-unpublish-on with #edit-unpublish-on-date
- Remove references to non-existent datepicker popup selectors (#edit-publish-on-datepicker-popup-0 and #edit-unpublish-on-datepicker-popup-0)

The tab summary now correctly displays "Scheduled for publishing", "Scheduled for unpublishing", or "Not scheduled" based on the actual state of the date inputs.

Fixes #28